### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/netcalc.go
+++ b/netcalc.go
@@ -78,6 +78,9 @@ func parseInput(args []string) (string, uint, error) {
 				if err != nil {
 					return "", 0, fmt.Errorf("invalid mask octet: %s", p)
 				}
+				if v < 0 || v > 255 {
+					return "", 0, fmt.Errorf("mask octet out of range: %d", v)
+				}
 				maskBytes[i] = byte(v)
 			}
 			ones, bits := net.IPMask(maskBytes[:]).Size()


### PR DESCRIPTION
Potential fix for [https://github.com/galenoferreira/netcalc/security/code-scanning/2](https://github.com/galenoferreira/netcalc/security/code-scanning/2)

To fix the issue, we need to add an explicit bounds check to ensure that the value of `v` is within the range of `uint8` (0–255) before converting it to a `byte`. If the value is out of bounds, the function should return an appropriate error message. This ensures that the conversion is safe and prevents unexpected behavior.

The changes will be made in the `parseInput` function, specifically in the loop that processes `maskParts` on lines 76–81.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
