### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/galenoferreira/netcalc/security/code-scanning/1](https://github.com/galenoferreira/netcalc/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only builds and tests the code, it does not require write access to the repository. The `permissions` block should be added at the root level of the workflow to apply to all jobs. The minimal permissions required are `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
